### PR TITLE
Potential fix for code scanning alert no. 42: Missing rate limiting

### DIFF
--- a/step6/package.json
+++ b/step6/package.json
@@ -31,7 +31,8 @@
     "express": "^4.18.3",
     "jsonwebtoken": "^9.0.1",
     "mongoose": "7.4",
-    "validator": "^13.11.0"
+    "validator": "^13.11.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.1",

--- a/step6/server.js
+++ b/step6/server.js
@@ -3,12 +3,24 @@ import bodyParser from 'body-parser'
 import * as whisper from './stores/whisper.js'
 import * as user from './stores/user.js'
 import { generateToken, requireAuthentication } from './utils.js'
+import rateLimit from 'express-rate-limit'
 
 const app = express()
+
+// Rate limiter: adjust windowMs and max as appropriate for your use case
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per 'window' (here, per 15 minutes)
+  standardHeaders: true, // Return rate limit info in the RateLimit-* headers
+  legacyHeaders: false, // Disable the X-RateLimit-* headers
+})
+
 app.use(express.static('public'))
 app.use(bodyParser.json())
 app.set('view engine', 'ejs')
 
+// Apply rate limiter to all /api/ routes (can narrow if desired)
+app.use('/api/', apiLimiter)
 app.get('/login', (req, res) => {
   res.render('login')
 })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/42](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/42)

The recommended fix is to add a rate-limiting middleware to the Express app to limit the number of requests a client can make in a given time window, especially for endpoints performing expensive database operations. The best practice is to use the `express-rate-limit` package for its reliability and ease of integration. 

You'll need to:
- Import `express-rate-limit` at the top of `step6/server.js`.
- Create a rate limiter instance (e.g., allow 100 requests per 15 minutes per IP — you can adjust as per your needs).
- Apply the rate limiter middleware to all API routes or, more specifically, to `/api/v1/whisper/:id` and other sensitive endpoints. For simplicity and better protection, it's common to apply the limiter to all `/api/` endpoints, or globally.

This change keeps existing functionality intact while adding the necessary protection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
