### PR TITLE
Potential fix for code scanning alert no. 5: Database query built from user-controlled sources

### DIFF
--- a/step5/server.js
+++ b/step5/server.js
@@ -75,7 +75,7 @@ app.post('/api/v1/whisper', requireAuthentication, async (req, res) => {
 app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   const { message } = req.body
   const id = req.params.id
-  if (!message) {
+  if (typeof message !== 'string' || !message) {
     res.sendStatus(400)
     return
   }

--- a/step5/stores/whisper.js
+++ b/step5/stores/whisper.js
@@ -9,7 +9,16 @@ const create = async (message, authorId) => {
   await whisper.save()
   return whisper
 }
-const updateById = async (id, message) => Whisper.findOneAndUpdate({ _id: id }, { message }, { new: false })
+const updateById = async (id, message) => {
+  if (typeof message !== 'string') {
+    throw new Error('Invalid message: must be a string');
+  }
+  return Whisper.findOneAndUpdate(
+    { _id: id },
+    { $set: { message } },
+    { new: false }
+  );
+}
 const deleteById = async (id) => Whisper.deleteOne({ _id: id })
 
 export { getAll, getById, create, updateById, deleteById }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/5](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/5)

To fix this vulnerability, we need to ensure that the `message` field passed from the user is always treated as a literal value and not as a query/update operator, preventing NoSQL (operator) injection. The safest way is to check the type of `message` and only proceed if it is a string (or the expected type). This should be enforced before calling `Whisper.findOneAndUpdate`. 

Two places can be fixed: (a) at the route handler level (in step5/server.js, in the PUT handler), and/or (b) inside the `updateById` method (in step5/stores/whisper.js). For robustness, the check should be added inside `updateById` to ensure proper use even if called from other places.

Specifically, in `updateById`, before performing the update, check that `message` is a string; if not, throw an error or return without updating (or you may reject the update with an error or status code from the router handler). This check ensures that only a string can be written to the database as `message`.

Alternatively, for extra safety, you may use the `$set` operator explicitly in the update, i.e., `{ $set: { message } }`, and type-check `message`. This will further ensure that the update is never interpreted as an operator injection.

**Files/regions/lines to change:**
- step5/stores/whisper.js: In `updateById`, check `typeof message === "string"` before proceeding. If not a string, throw an error or return a rejected Promise.
- (Optional but advisable) In server.js, in the PUT handler, check that `message` is a string, and respond with `400 Bad Request` if not.

**Methods/imports/definitions needed:** No new imports are necessary. Use standard JavaScript `typeof` operator for the type check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
