### PR TITLE
Potential fix for code scanning alert no. 33: Missing rate limiting

### DIFF
--- a/step6/server.js
+++ b/step6/server.js
@@ -54,7 +54,7 @@ app.post('/signup', async (req, res) => {
   }
 })
 
-app.get('/about', async (req, res) => {
+app.get('/about', apiLimiter, async (req, res) => {
   const whispers = await whisper.getAll()
   res.render('about', { whispers })
 })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/33](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/33)

To fix the issue, add rate-limiting middleware to the `/about` route. This can be achieved by applying the existing `apiLimiter` rate limiter (or a custom limiter for UI routes if desired) to the `/about` route's handler. Since the limiter is already defined in the file (`apiLimiter` variable), add it as a second argument to the `app.get('/about', ...)` declaration so that requests to `/about` will first pass through rate limiting before reaching the expensive database call.

No new imports, methods, or definitions are needed, as the rate-limiting middleware is already imported and configured. Only a code edit is needed for the `/about` route declaration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
