### PR TITLE
Potential fix for code scanning alert no. 32: Missing rate limiting

### DIFF
--- a/step5/package.json
+++ b/step5/package.json
@@ -31,7 +31,8 @@
     "express": "^4.18.3",
     "jsonwebtoken": "^9.0.1",
     "mongoose": "7.4",
-    "validator": "^13.11.0"
+    "validator": "^13.11.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.24.1",

--- a/step5/server.js
+++ b/step5/server.js
@@ -4,7 +4,17 @@ import * as whisper from './stores/whisper.js'
 import * as user from './stores/user.js'
 import { generateToken, requireAuthentication } from './utils.js'
 
+// Import express-rate-limit for rate limiting sensitive endpoints
+import rateLimit from 'express-rate-limit'
+
 const app = express()
+// Define a rate limiter for DELETE requests (e.g., max 10 per 15 minutes)
+const deleteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit each IP to 10 delete requests per windowMs
+  message: 'Too many delete requests from this IP, please try again later'
+})
+
 app.use(express.static('public'))
 app.use(bodyParser.json())
 app.set('view engine', 'ejs')
@@ -93,7 +103,7 @@ app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   res.sendStatus(200)
 })
 
-app.delete('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.delete('/api/v1/whisper/:id', deleteLimiter, requireAuthentication, async (req, res) => {
   const id = req.params.id
   const storedWhisper = await whisper.getById(id)
   if (!storedWhisper) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/32](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/32)

To fix the problem, we should introduce request rate limiting to the `/api/v1/whisper/:id` DELETE endpoint to prevent excessive resource consumption during database access. The best way to achieve this in Express, as shown in the example, is to use the `express-rate-limit` middleware. We'll import the library, define a limiter (e.g., restrict to N deletions per user/IP per time window), and apply it specifically to the `/api/v1/whisper/:id` DELETE route.

The following changes are needed in `step5/server.js`:
- Add an import (using `require` due to package conventions for `express-rate-limit`).
- Define a limiter (for demonstration: 10 deletes per 15 minutes per IP).
- Apply this limiter as middleware to the DELETE route only.

If ESM is strictly enforced, we may need to import using dynamic `import()`, but by convention and compatibility, most use `require` for this middleware. We make as minimal changes as possible in the given code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
