### PR TITLE
Potential fix for code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/step5/package.json
+++ b/step5/package.json
@@ -31,7 +31,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "8.18",
-    "validator": "^13.15.15"
+    "validator": "^13.15.15",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",

--- a/step5/server.js
+++ b/step5/server.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import bodyParser from 'body-parser'
+import rateLimit from 'express-rate-limit'
 import * as whisper from './stores/whisper.js'
 import * as user from './stores/user.js'
 import { generateToken, requireAuthentication } from './utils.js'
@@ -8,7 +9,6 @@ const app = express()
 app.use(express.static('public'))
 app.use(bodyParser.json())
 app.set('view engine', 'ejs')
-
 app.get('/login', (req, res) => {
   res.render('login')
 })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/30](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/30)

To fix this, we should add a rate limiting middleware—typically using the well-known `express-rate-limit` library. We should limit the number of requests to the API endpoints and sensitive public endpoints (such as `/login` and `/signup`). The best approach is to:

- Install `express-rate-limit` (if it isn’t present).
- Import and configure a limiter, e.g., allowing 100 requests per 15 minutes (could be tweaked for stricter limits per route).
- Apply this limiter to all routes that perform database access: especially all `/api/v1/whisper/*`, `/login`, and `/signup` POST endpoints.
- The code change is in step5/server.js: Add the import at the top, set up the limiter after initializing the Express app, and apply it as a middleware to the relevant routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
