### PR TITLE
Potential fix for code scanning alert no. 28: Missing rate limiting

### DIFF
--- a/step5/server.js
+++ b/step5/server.js
@@ -16,6 +16,13 @@ const deleteLimiter = rateLimit({
   message: 'Too many delete requests from this IP, please try again later'
 })
 
+// Define a rate limiter for POST requests (e.g., max 100 per 15 minutes)
+const postLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 POST requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+})
 app.use(express.static('public'))
 app.use(bodyParser.json())
 app.set('view engine', 'ejs')
@@ -72,7 +79,7 @@ app.get('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   }
 })
 
-app.post('/api/v1/whisper', requireAuthentication, async (req, res) => {
+app.post('/api/v1/whisper', postLimiter, requireAuthentication, async (req, res) => {
   const { message } = req.body
   if (!message) {
     res.sendStatus(400)


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/28](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/28)

To address the missing rate limiting, you should apply the existing (or a similar) rate limiting middleware to the `POST /api/v1/whisper` endpoint. Since a rate limiter (`deleteLimiter`) is already defined and used for the DELETE route, you can define a similar rate limiter (e.g., `postLimiter`) specifically for POST requests that create new whispers. The best fix is to:

1. Define a new rate limiter (e.g., `postLimiter`) with appropriate limits (for instance, 100 requests per 15 minutes, adjust as needed).
2. Add `postLimiter` as middleware to the `POST /api/v1/whisper` route (on line 75), right before `requireAuthentication`.
   
Required changes:
- Insert a definition of the rate limiter just after `deleteLimiter` or in the same region (after line 17 or before route setup).
- Add the `postLimiter` middleware to the POST whisper route on line 75.
- No new imports are required, since `express-rate-limit` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
