### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/step5/server.js
+++ b/step5/server.js
@@ -16,6 +16,13 @@ const deleteLimiter = rateLimit({
   message: 'Too many delete requests from this IP, please try again later'
 })
 
+// Define a rate limiter for GET whisper by ID requests (e.g., max 100 per 15 minutes)
+const getWhisperLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 get requests per windowMs
+  message: 'Too many whisper requests from this IP, please try again later'
+});
+
 app.use(express.static('public'))
 app.use(bodyParser.json())
 app.set('view engine', 'ejs')
@@ -62,7 +69,7 @@ app.get('/api/v1/whisper', requireAuthentication, async (req, res) => {
   res.json(whispers)
 })
 
-app.get('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.get('/api/v1/whisper/:id', getWhisperLimiter, requireAuthentication, async (req, res) => {
   const id = req.params.id
   const storedWhisper = await whisper.getById(id)
   if (!storedWhisper) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/27](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/27)

To fix this error, we should add a rate limiting middleware to the `/api/v1/whisper/:id` GET route. The best way to do this is to define a rate limiter specifically for this endpoint or to reuse the existing `deleteLimiter` but ideally define a separate limiter for GET requests, e.g., `getWhisperLimiter`. This should restrict the number of requests that can be made to this endpoint from a given IP within a certain window, preventing abuse and possible denial-of-service attacks. We'll:
- Add a new rate limiter for GET requests to `/api/v1/whisper/:id`, e.g., 100 requests per 15 minutes.
- Import is already present.
- Add the middleware to the route on line 65.
No existing functionality is changed except the addition of the rate limit.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
