### PR TITLE
Potential fix for code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/step4/stores/whisper.js
+++ b/step4/stores/whisper.js
@@ -9,7 +9,7 @@ const create = async (message, authorId) => {
   await whisper.save()
   return whisper
 }
-const updateById = async (id, message) => Whisper.findOneAndUpdate({ _id: id }, { message }, { new: false })
+const updateById = async (id, message) => Whisper.findOneAndUpdate({ _id: id }, { $set: { message } }, { new: false })
 const deleteById = async (id) => Whisper.deleteOne({ _id: id })
 
 export { getAll, getById, create, updateById, deleteById }


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/3](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/3)

To prevent NoSQL injection, we should ensure that user input is treated strictly as a literal value, not allowed to contain query or operator objects. The recommended way is, before passing `message` to the update, either:

- Use MongoDB's `$set` explicitly: update only the `message` field.
- Or (additionally or alternatively) validate the type of `message` (e.g., ensure `typeof message === 'string'` or that it is a primitive value).

The single best fix here is to modify the `updateById` function to use the `$set` operator when updating the `message` field, ensuring that only the value (and not an operator object) is ever interpreted by MongoDB.

This only requires modifying the relevant line in `step4/stores/whisper.js`, updating the second argument to `findOneAndUpdate` to `{$set: {message}}` instead of `{message}`. There is no need to change imports or add new functions, unless additional type checking is wanted (not strictly required if using `$set`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
