### PR TITLE
Potential fix for code scanning alert no. 9: Missing rate limiting

### DIFF
--- a/step3/package.json
+++ b/step3/package.json
@@ -28,7 +28,8 @@
     "dotenv": "^17.2.2",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
-    "mongoose": "8.18"
+    "mongoose": "8.18",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",

--- a/step3/server.js
+++ b/step3/server.js
@@ -1,12 +1,21 @@
 import express from 'express'
 import bodyParser from 'body-parser'
 import { getAll, getById, create, updateById, deleteById } from './store.js'
+import rateLimit from 'express-rate-limit'
 
 const app = express()
 app.use(express.static('public'))
 app.use(bodyParser.json())
 app.set('view engine', 'ejs')
 
+// Set up rate limiter for API routes to help prevent abuse
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100 // Limit each IP to 100 requests per windowMs
+});
+
+// Apply rate limiter to all /api/v1/whisper routes
+app.use('/api/v1/whisper', apiLimiter)
 app.get('/about', async (req, res) => {
   const whispers = await getAll()
   res.render('about', { whispers })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/9](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/9)

The best way to fix this issue is to apply a rate-limiting middleware to the Express application, making use of a well-established package such as `express-rate-limit`. This can be accomplished by importing the middleware, defining appropriate rate limiting parameters (e.g., maximum number of requests per window), and adding the middleware before the API route(s) that interact with the database. To address the issue flagged by CodeQL, we should at minimum apply the rate limiter to all `/api/v1/whisper*` routes (GET, POST, PUT, DELETE), but can also apply it more broadly (e.g., to all `/api` routes). The fix only requires editing `step3/server.js`, adding a dependency import, defining the limiter, and using it for the relevant routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
