### PR TITLE
Potential fix for code scanning alert no. 18: Missing rate limiting

### DIFF
--- a/step4/package.json
+++ b/step4/package.json
@@ -31,7 +31,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "8.18",
-    "validator": "^13.15.15"
+    "validator": "^13.15.15",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",

--- a/step4/server.js
+++ b/step4/server.js
@@ -80,7 +80,7 @@ app.post('/api/v1/whisper', requireAuthentication, whisperLimiter, async (req, r
   res.status(201).json(newWhisper)
 })
 
-app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.put('/api/v1/whisper/:id', requireAuthentication, whisperLimiter, async (req, res) => {
   const { message } = req.body
   const id = req.params.id
   if (!message) {
@@ -101,7 +101,7 @@ app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   res.sendStatus(200)
 })
 
-app.delete('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.delete('/api/v1/whisper/:id', requireAuthentication, whisperLimiter, async (req, res) => {
   const id = req.params.id
   const storedWhisper = await whisper.getById(id)
   if (!storedWhisper) {

--- a/step4/server.js
+++ b/step4/server.js
@@ -1,8 +1,16 @@
 import express from 'express'
 import bodyParser from 'body-parser'
 import * as whisper from './stores/whisper.js'
+import rateLimit from 'express-rate-limit'
 import * as user from './stores/user.js'
 import { generateToken, requireAuthentication } from './utils.js'
+
+
+// Set up rate limiter for sensitive endpoints
+const whisperLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+})
 
 const app = express()
 app.use(express.static('public'))
@@ -62,7 +70,7 @@ app.get('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   }
 })
 
-app.post('/api/v1/whisper', requireAuthentication, async (req, res) => {
+app.post('/api/v1/whisper', requireAuthentication, whisperLimiter, async (req, res) => {
   const { message } = req.body
   if (!message) {
     res.sendStatus(400)


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/18](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/18)

To fix the missing rate limiting, a rate-limiting middleware should be added to this endpoint (and possibly other routes involving expensive operations). The industry-standard way in Express apps is to use the `express-rate-limit` package. You must import this package, configure a limiter (choosing sensible defaults, e.g. 100 requests per 15 minutes per IP), and insert it just before the handler for the `/api/v1/whisper` POST route, alongside the `requireAuthentication` middleware. This isolates the change to the specific file and region shown, introduces no breaking changes, and preserves all existing functionality.

You need to:  
- Add the `express-rate-limit` import at the top.  
- Define a rate limiter instance (e.g. `limiter`) with appropriate configuration.  
- Insert the rate limiter as a middleware for the `app.post('/api/v1/whisper', ...)` route, immediately before or after `requireAuthentication`.  
If other expensive API routes exist, e.g., whisper CRUD endpoints, they should also be protected, but per instructions, only update shown code and only the highlighted ("65: app.post...") location.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
