### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/step4/package.json
+++ b/step4/package.json
@@ -31,7 +31,8 @@
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "8.18",
-    "validator": "^13.15.15"
+    "validator": "^13.15.15",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.3",

--- a/step4/server.js
+++ b/step4/server.js
@@ -3,6 +3,13 @@ import bodyParser from 'body-parser'
 import * as whisper from './stores/whisper.js'
 import * as user from './stores/user.js'
 import { generateToken, requireAuthentication } from './utils.js'
+import rateLimit from 'express-rate-limit'
+
+const aboutLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+ max: 20, // limit each IP to 20 requests per minute to '/about'
+ message: 'Too many requests from this IP, please try again later.'
+})
 
 const app = express()
 app.use(express.static('public'))
@@ -42,7 +49,7 @@ app.post('/signup', async (req, res) => {
   }
 })
 
-app.get('/about', async (req, res) => {
+app.get('/about', aboutLimiter, async (req, res) => {
   const whispers = await whisper.getAll()
   res.render('about', { whispers })
 })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/13](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/13)

To fix the issue, we should apply rate limiting to routes that access the database, such as `/about`. This is typically done using middleware like `express-rate-limit`. 

The best approach is to:
- Install `express-rate-limit` and import it into the file.
- Create a rate limiter instance (e.g., allowing a reasonable number of requests per time window).
- Apply the rate limiter specifically to the `/about` route via middleware, so as not to affect unrelated routes, or more broadly if desired.

Changes to make:
- Import `express-rate-limit` near the top of the file.
- Define a `rateLimiter` instance.
- In the route definition for `/about`, add the rate limiter as a middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
