### PR TITLE
Potential fix for code scanning alert no. 14: Missing rate limiting

### DIFF
--- a/step4/server.js
+++ b/step4/server.js
@@ -11,6 +11,13 @@ const aboutLimiter = rateLimit({
  message: 'Too many requests from this IP, please try again later.'
 })
 
+// set up rate limiter for API routes: maximum of 100 requests per 15 minutes
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per 15 minutes
+  message: 'Too many requests, please try again later.'
+})
+
 const app = express()
 app.use(express.static('public'))
 app.use(bodyParser.json())
@@ -54,7 +61,7 @@ app.get('/about', aboutLimiter, async (req, res) => {
   res.render('about', { whispers })
 })
 
-app.get('/api/v1/whisper', requireAuthentication, async (req, res) => {
+app.get('/api/v1/whisper', requireAuthentication, apiLimiter, async (req, res) => {
   const whispers = await whisper.getAll()
   res.json(whispers)
 })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/14](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/14)

The best way to fix the problem is to apply a rate limiting middleware to the `/api/v1/whisper` GET route at line 57. This will ensure that even authenticated users (or compromised accounts) cannot perform unlimited expensive operations. The `express-rate-limit` package is already imported and used elsewhere, so we can replicate a similar pattern by creating a new `rateLimit` instance specific to API routes (or reuse the same one, if desired). 

To avoid affecting other routes, we should define a new limiter (e.g., `apiLimiter`)—for example, allowing 100 requests per 15 minutes per IP, which is a standard practice for API endpoints. Then, insert it as middleware in the affected route. Specifically, (a) define the limiter near existing middleware definitions (e.g., after `aboutLimiter`), then (b) apply it to `app.get('/api/v1/whisper', requireAuthentication, ...)`. No changes to existing functionality will occur, and we stick to proven best practices.

**Required changes**:
- Add a new API rate limiter definition (`apiLimiter`) after `aboutLimiter`.
- Apply `apiLimiter` as a middleware on line 57 to the `/api/v1/whisper` GET route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
