### PR TITLE
Potential fix for code scanning alert no. 15: Missing rate limiting

### DIFF
--- a/step4/server.js
+++ b/step4/server.js
@@ -11,6 +11,13 @@ const aboutLimiter = rateLimit({
  message: 'Too many requests from this IP, please try again later.'
 })
 
+// Rate limiter for /api/v1/whisper GET route
+const apiWhisperLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  message: 'Too many requests, please try again later.'
+})
+
 const app = express()
 app.use(express.static('public'))
 app.use(bodyParser.json())
@@ -54,7 +61,7 @@ app.get('/about', aboutLimiter, async (req, res) => {
   res.render('about', { whispers })
 })
 
-app.get('/api/v1/whisper', requireAuthentication, async (req, res) => {
+app.get('/api/v1/whisper', requireAuthentication, apiWhisperLimiter, async (req, res) => {
   const whispers = await whisper.getAll()
   res.json(whispers)
 })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/15](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/15)

To fix the problem, we should introduce rate limiting to the `/api/v1/whisper` GET endpoint to restrict how often a single client (by IP) can request all whispers. The simplest and most robust approach is to create a rate limiter instance through the already-imported `express-rate-limit` package, similar to `aboutLimiter`, and apply it to this route. It is preferable to tune the parameters so the limit is appropriate for API queries, such as 100 requests per 15 minutes for each IP. The limiter should be initialized above route definitions and passed as the first middleware argument to the handler on line 57.

Concrete actions:
- In step4/server.js, define a new `apiWhisperLimiter` just above the route definitions, e.g. after `aboutLimiter`.
- On line 57, add `apiWhisperLimiter` as a middleware to the `/api/v1/whisper` GET handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
