### PR TITLE
Potential fix for code scanning alert no. 29: Missing rate limiting

### DIFF
--- a/step5/server.js
+++ b/step5/server.js
@@ -5,8 +5,7 @@ import * as whisper from './stores/whisper.js'
 import * as user from './stores/user.js'
 import { generateToken, requireAuthentication } from './utils.js'
 
-// Import express-rate-limit for rate limiting sensitive endpoints
-import rateLimit from 'express-rate-limit'
+
 
 const app = express()
 // Define a rate limiter for DELETE requests (e.g., max 10 per 15 minutes)
@@ -15,6 +14,13 @@ const deleteLimiter = rateLimit({
   max: 10, // limit each IP to 10 delete requests per windowMs
   message: 'Too many delete requests from this IP, please try again later'
 })
+// Define a rate limiter for PUT requests (e.g., max 10 per 15 minutes)
+const putLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // limit each IP to 10 put requests per windowMs
+  message: 'Too many update requests from this IP, please try again later'
+})
+
 
 // Define a rate limiter for POST requests (e.g., max 100 per 15 minutes)
 const postLimiter = rateLimit({
@@ -97,7 +103,7 @@ app.post('/api/v1/whisper', postLimiter, requireAuthentication, async (req, res)
   res.status(201).json(newWhisper)
 })
 
-app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.put('/api/v1/whisper/:id', putLimiter, requireAuthentication, async (req, res) => {
   const { message } = req.body
   const id = req.params.id
   if (typeof message !== 'string' || !message) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/29](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/29)

To fix the issue, apply rate limiting to the PUT `/api/v1/whisper/:id` endpoint in `step5/server.js`, just as is done for the POST, GET, and DELETE whisper endpoints. This will involve:
- Creating (if not already present) a specific rate limiter instance for PUT requests, e.g., `putLimiter`. The configuration (such as `windowMs` and `max`) should be chosen based on security and usability but should match or be similar to the limits set for POST and DELETE.
- Adding the `putLimiter` middleware to the PUT route, so the request will be rejected if the calling client has exceeded the rate limit.
- Importing `rateLimit` only once at the top (the file contains two imports for `express-rate-limit`; one can be removed if present).

All edits must take place within `step5/server.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
