### PR TITLE
Potential fix for code scanning alert no. 22: Missing rate limiting

### DIFF
--- a/step4/server.js
+++ b/step4/server.js
@@ -11,6 +11,13 @@ const aboutLimiter = rateLimit({
  message: 'Too many requests from this IP, please try again later.'
 })
 
+// API rate limiter: limit each IP to 100 requests per 15 minutes
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per window
+  message: 'Too many requests to whisper endpoints from this IP, please try again later.'
+})
+
 // Limit "dangerous" API calls (such as deletes) to 10 per minute per IP
 const apiLimiter = rateLimit({
   windowMs: 1 * 60 * 1000, // 1 minute
@@ -66,7 +73,7 @@ app.get('/api/v1/whisper', requireAuthentication, async (req, res) => {
   res.json(whispers)
 })
 
-app.get('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.get('/api/v1/whisper/:id', requireAuthentication, apiLimiter, async (req, res) => {
   const id = req.params.id
   const storedWhisper = await whisper.getById(id)
   if (!storedWhisper) {
@@ -76,7 +83,7 @@ app.get('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   }
 })
 
-app.post('/api/v1/whisper', requireAuthentication, async (req, res) => {
+app.post('/api/v1/whisper', requireAuthentication, apiLimiter, async (req, res) => {
   const { message } = req.body
   if (!message) {
     res.sendStatus(400)
@@ -86,7 +93,7 @@ app.post('/api/v1/whisper', requireAuthentication, async (req, res) => {
   res.status(201).json(newWhisper)
 })
 
-app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.put('/api/v1/whisper/:id', requireAuthentication, apiLimiter, async (req, res) => {
   const { message } = req.body
   const id = req.params.id
   if (!message) {

--- a/step4/server.js
+++ b/step4/server.js
@@ -11,6 +11,13 @@ const aboutLimiter = rateLimit({
  message: 'Too many requests from this IP, please try again later.'
 })
 
+// Limit "dangerous" API calls (such as deletes) to 10 per minute per IP
+const apiLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 10, // limit each IP to 10 requests per minute
+  message: 'Too many delete requests from this IP, please try again later.'
+})
+
 const app = express()
 app.use(express.static('public'))
 app.use(bodyParser.json())
@@ -100,7 +107,7 @@ app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   res.sendStatus(200)
 })
 
-app.delete('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.delete('/api/v1/whisper/:id', requireAuthentication, apiLimiter, async (req, res) => {
   const id = req.params.id
   const storedWhisper = await whisper.getById(id)
   if (!storedWhisper) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/22](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/22)

To fix the problem, add a rate limiter middleware to the affected route: `DELETE /api/v1/whisper/:id`. Since the project already uses `express-rate-limit` elsewhere, use it for consistency. Create a limiter instances suitable for API routes (e.g., allowing a reasonable number of deletions per minute from the same IP) and apply it to the route as middleware.

The changes should be made within the route definition in `step4/server.js`, by:

- Defining a limiter constant (e.g., `apiLimiter`) with configuration suitable for API routes.
- Applying the limiter to the route (i.e., add it to the middleware list for the DELETE handler, between `requireAuthentication` and the handler).

You also need to pick a sensible default for the route—e.g., 10 delete requests per minute per IP.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
